### PR TITLE
metricsが空でない場合のみcloud monitoringに投稿する

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,7 +101,10 @@ func main() {
 		}
 		metrics = append(metrics, metric)
 	}
-	if err := throwMetrics(ctx, *client, desc, metrics); err != nil {
-		log.Fatal(err)
+
+	if len(metrics) != 0 {
+		if err := throwMetrics(ctx, *client, desc, metrics); err != nil {
+			log.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
ref: https://github.com/syou6162/cloud_monitoring_metrics_throw/pull/15

空メトリックのときを考慮する必要があった。考慮しないと、こうなる。

```
2022/05/02 18:04:31 rpc error: code = InvalidArgument desc = Request was missing field timeSeries.
```